### PR TITLE
Push commits even when empty

### DIFF
--- a/src/clj_github/changeset.clj
+++ b/src/clj_github/changeset.clj
@@ -93,16 +93,13 @@
 
 (defn commit!
   "Commits the changeset returning a new changeset based on the new commit revision.
-  If the changeset does not contain any changes, calling this function is a no-op.
   This function does not update the HEAD of a branch."
   [{:keys [client org repo base-revision changes] :as changeset} message]
-  (if (empty? changes)
-    changeset
-    (let [{:keys [sha]} (repository/commit! client org repo base-revision {:message  message
-                                                                           :tree     (changes->tree changes)})]
-      (-> changeset
-          (dissoc :changes)
-          (assoc :base-revision sha)))))
+  (let [{:keys [sha]} (repository/commit! client org repo base-revision {:message  message
+                                                                         :tree     (changes->tree changes)})]
+    (-> changeset
+        (dissoc :changes)
+        (assoc :base-revision sha))))
 
 (defn- branch-ref [branch]
   (format "heads/%s" branch))

--- a/test/clj_github/changeset_test.clj
+++ b/test/clj_github/changeset_test.clj
@@ -7,7 +7,7 @@
 
 (defmacro with-client [[client initial-state] & body]
   `(fake/with-fake-http
-     [#"^https://api.github.com/repos/.*" (mock.core/httpkit-fake-handler {:initial-state initial-state})]
+     [#"^https://api.github.com/repos/.*" (mock.core/httpkit-fake-handler {:initial-state ~initial-state})]
      (let [~client (client/new-client {:token-fn (constantly "token")})]
        ~@body)))
 


### PR DESCRIPTION
Change the `commit!` api such that it pushes commits even if the changeset is empty, which is useful for registering a new branch without changing anything