### PR TITLE
Allow passing expressions into mock-github-flow macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## 0.1.1
+- Allow passing expressions (along with map values) to the `clj-github.state-flow-helper/mock-github-flow` macro
+
 ## 0.1.0
 - Initial version

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dev.nubank/clj-github "0.1.0"
+(defproject dev.nubank/clj-github "0.1.1"
   :description "A Clojure library for interacting with the github developer API"
   :url "https://github.com/nubank/clj-github"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/clj_github/state_flow_helper.clj
+++ b/src/clj_github/state_flow_helper.clj
@@ -41,7 +41,7 @@
           (let [seed-data#       ~seed-data-expr
                 faked-responses# (test-helpers/build-spec (or (:responses seed-data#) []))
                 mocked-handler#  (mock.core/httpkit-fake-handler
-                                  {:initial-state (:initial-state seed-data#)})]
+                                  (select-keys seed-data# [:initial-state]))]
             (concat faked-responses#
                     [#"^https://api.github.com/.*" mocked-handler#])))
         (f#)))

--- a/src/clj_github/state_flow_helper.clj
+++ b/src/clj_github/state_flow_helper.clj
@@ -32,14 +32,18 @@
 
   This is backed up by `http-kit-fake`, for more details on how to declare requests and responses
   see https://github.com/d11wtq/http-kit-fake."
-  [{:keys [initial-state responses] :or {responses []}} & flows]
+  [seed-data-expr & flows]
   `(state/wrap-with
     (fn [f#]
       (fake/with-fake-http
-        ~(into
+        (into
           []
-          (concat (test-helpers/build-spec responses)
-                  `[#"^https://api.github.com/.*" (mock.core/httpkit-fake-handler {:initial-state ~initial-state})]))
+          (let [seed-data#       ~seed-data-expr
+                faked-responses# (test-helpers/build-spec (or (:responses seed-data#) []))
+                mocked-handler#  (mock.core/httpkit-fake-handler
+                                  {:initial-state (:initial-state seed-data#)})]
+            (concat faked-responses#
+                    [#"^https://api.github.com/.*" mocked-handler#])))
         (f#)))
     (flow/flow "mock-github"
                ~@flows)))


### PR DESCRIPTION
allows for abstracting away duplicate code the build the seed data

for instance, the following wasn't working before this change

```clojure
(defn initial-state [org repository responses]
  {:responses responses
   :initial-state {:orgs [{:name org
                           :repos [{:name           repository
                                    :default_branch "main"}]}]}})

(def x 
  (initial-state
   org
   repository 
   [(create-pr-request? "[Auto] Refactors -" [remove-file-migration]) "{\"number\": 2}"
    (add-label-request? 2) "{}"]))

(defflow applying+skipping-migrations
  (mock-github-flow x (flow ....)))
```
