### PR TITLE
Only convert response to clojure data when response is json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.0
+- Support content types other than json
+
 ## 0.2.2
 - Fix breaking change in exception result
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dev.nubank/clj-github "0.2.2"
+(defproject dev.nubank/clj-github "0.3.0"
   :description "A Clojure library for interacting with the github developer API"
   :url "https://github.com/nubank/clj-github"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/clj_github/httpkit_client.clj
+++ b/src/clj_github/httpkit_client.clj
@@ -33,7 +33,7 @@
   (let [response @(httpkit/request (prepare client req-map))]
     (if (success-codes (:status response))
       (update response :body (partial parse-body (content-type response)))
-      (throw (ex-info "Request to GitHub failed" {:response (select-keys response [:status :body]))))))
+      (throw (ex-info "Request to GitHub failed" {:response (select-keys response [:status :body])})))))
 
 (defn new-client [{:keys [app-id private-key token org] :as opts}]
   (cond

--- a/test/clj_github/httpkit_client_test.clj
+++ b/test/clj_github/httpkit_client_test.clj
@@ -1,31 +1,34 @@
 (ns clj-github.httpkit-client-test
   (:require [clojure.test :refer [deftest is testing]]
             [clj-github.httpkit-client :as sut]
-            [matcher-combinators.test :refer [match?]]
+            [matcher-combinators.clj-test]
             [org.httpkit.fake :refer [with-fake-http]]))
 
 (deftest request-test
   (let [client (sut/new-client {:token-fn (fn [] "token")})]
     (testing "default method is get"
       (with-fake-http [{:method :get}
-                       "\"result\""]
-        (is "result" (sut/request client {}))))
-    (testing "body is converted to json"
+                       {:status 200}]
+        (is (match? {:status 200} (sut/request client {})))))
+    (testing "body is converted to clojure data if content type is json"
       (with-fake-http [{:body "{\"key\":\"value\"}"}
-                       "\"result\""]
-        (is "result" (sut/request client {:body {:key "value"}}))))
+                       {:headers {:content-type "application/json; charset=utf-8"}
+                        :body "{\"value\":\"result\"}"}]
+        (is (match? {:body {:value "result"}} (sut/request client {:body {:key "value"}})))))
+    (testing "body is not converted if content type is not json"
+      (with-fake-http [{:body "{\"key\":\"value\"}"}
+                       {:headers {:content-type "some-other-content-type"}
+                        :body "{\"value\":\"result\"}"}]
+        (is  (match? {:body "{\"value\":\"result\"}"} (sut/request client {:body {:key "value"}})))))
     (testing "path is appended to url"
       (with-fake-http [{:url "https://api.github.com/path"}
-                       "\"result\""]
-        (is "result" (sut/request client {:path "/path"}))))
+                       {:status 200}]
+        (is (match? {:status 200} (sut/request client {:path "/path"})))))
     (testing "github token is added to authorization header"
       (with-fake-http [{:headers {"Authorization" "Bearer token"
                                   "Content-Type" "application/json"}}
-                       "\"result\""]
-        (is "result" (sut/request client {}))))
-    (testing "it converts response to clojure data"
-      (with-fake-http [{} "{\"key\":\"value\"}"]
-        (is {:key "value"} (sut/request client {}))))
+                       {:status 200}]
+        (is (match? {:status 200} (sut/request client {})))))
     (testing "it throws an exception when status code is not succesful"
       (with-fake-http [{} {:status 400}]
         (is (thrown? clojure.lang.ExceptionInfo #"Request to GitHub failed"

--- a/test/clj_github/test_helpers_test.clj
+++ b/test/clj_github/test_helpers_test.clj
@@ -7,16 +7,16 @@
 (deftest with-fake-github-test
   (let [client (httpkit-client/new-client {:token-fn (fn [] "token")})]
     (testing "it appends github url when request is a string"
-      (is (match? {:body {}}
-                  (sut/with-fake-github ["/api/repos" "{}"]
+      (is (match? {:status 200}
+                  (sut/with-fake-github ["/api/repos" {:status 200}]
                     (httpkit-client/request client {:path "/api/repos"})))))
     (testing "it supports a path attribute in a request map"
-      (is (match? {:body {}}
-                  (sut/with-fake-github [{:path "/api/repos"} "{}"]
+      (is (match? {:status 200} 
+                  (sut/with-fake-github [{:path "/api/repos"} {:status 200}]
                     (httpkit-client/request client {:path "/api/repos"})))))
     (testing "it supports regexes"
-      (is (match? {:body {}}
-                  (sut/with-fake-github [#"/api/repos" "{}"]
+      (is (match? {:status 200} 
+                  (sut/with-fake-github [#"/api/repos" {:status 200}]
                     (httpkit-client/request client {:path "/api/repos"})))))
 
     (testing "it supports functions as request spec"
@@ -25,14 +25,14 @@
             request-fn-with-arg (fn [url-regex]
                                   (fn [request]
                                     (re-find url-regex (:url request))))]
-        (is (match? {:body {}}
+        (is (match? {:status 200} 
                     (sut/with-fake-github ["/other" "{}"
-                                           (request-fn-with-arg #"/api/whatever") {:body "{}"}]
+                                           (request-fn-with-arg #"/api/whatever") {:status 200}]
                       (httpkit-client/request client {:path "/other"})
                       (httpkit-client/request client {:path "/api/whatever"}))))
 
-        (is (match? {:body {}}
+        (is (match? {:status 200}
                     (sut/with-fake-github ["/other" "{}"
-                                           request-fn {:body "{}"}]
+                                           request-fn {:status 200}]
                       (httpkit-client/request client {:path "/other"})
                       (httpkit-client/request client {:path "/api/repos"}))))))))


### PR DESCRIPTION
This is to allow calling endpoints that do not return json (e.g. https://docs.github.com/en/rest/reference/repos#download-a-repository-archive-tar).