### PR TITLE
Add clone repository function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.4.0
+- Add function that downloads repository content 
+
 ## 0.3.0
 - Support content types other than json
 

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,8 @@
                  [clj-commons/clj-yaml "0.7.106"]
                  [http-kit "2.5.3"]
                  [nubank/clj-github-app "0.1.4"]
-                 [nubank/state-flow "5.11.3"]]
+                 [nubank/state-flow "5.11.3"]
+                 [clj-commons/fs "1.6.307"]]
 
   :cljfmt {:indents {flow       [[:block 1]]
                      assoc-some [[:block 0]]}}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dev.nubank/clj-github "0.3.0"
+(defproject dev.nubank/clj-github "0.4.0"
   :description "A Clojure library for interacting with the github developer API"
   :url "https://github.com/nubank/clj-github"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/clj_github/repository.clj
+++ b/src/clj_github/repository.clj
@@ -200,7 +200,7 @@
                          :body   params})))
 
 (defn clone
-  "Download github repository and put content on destination path.
+  "Download github repository and put its content on a temporary dir. Returns the path of the temporary dir.
 
   For details about the parameters and response format, look at https://docs.github.com/en/rest/reference/repos#download-a-repository-archive-zip."
   ([client org repo]

--- a/src/clj_github/repository.clj
+++ b/src/clj_github/repository.clj
@@ -204,17 +204,15 @@
   ([client org repo dest]
    (clone client org repo "master" dest))
   ([client org repo tag dest]
-   (let [clone-path "/tmp/clone-repo/"
-         url (format "/repos/%/%/zipball/%" org repo tag)
+   (let [clone-path (str (fs/temp-dir "clone-repo") "/")
+         url (format "/repos/%s/%s/zipball/%s" org repo tag)
          git-response (client/request client {:path   url
                                               :method :get
                                               :as     :byte-array})
          filename (->> git-response :headers :content-disposition (re-find #"filename=(.*).zip") second)]
-     (fs/mkdir clone-path)
      (-> git-response
          :body
          (io/input-stream)
-         (io/copy (io/file (str clone-path "git-response.zip"))))
+         (io/copy (io/file clone-path "git-response.zip")))
      (fs-compression/unzip (str clone-path "git-response.zip") clone-path)
-     (fs/move (str clone-path filename) dest)
-     (fs/delete-dir clone-path))))
+     (fs/move (str clone-path filename) dest))))

--- a/src/clj_github/repository.clj
+++ b/src/clj_github/repository.clj
@@ -214,7 +214,7 @@
      (-> git-response
          :body
          (io/input-stream)
-         (clojure.java.io/copy (clojure.java.io/file (str clone-path "git-response.zip"))))
+         (io/copy (io/file (str clone-path "git-response.zip"))))
      (fs-compression/unzip (str clone-path "git-response.zip") clone-path)
      (fs/move (str clone-path filename) dest)
      (fs/delete-dir clone-path))))

--- a/src/clj_github/repository.clj
+++ b/src/clj_github/repository.clj
@@ -202,7 +202,7 @@
 (defn clone
   "Download github repository and put content on destination path"
   ([client org repo dest]
-   (clone client org repo "master" dest))
+   (clone client org repo "" dest))
   ([client org repo tag dest]
    (let [clone-path (str (fs/temp-dir "clone-repo") "/")
          url (format "/repos/%s/%s/zipball/%s" org repo tag)

--- a/src/clj_github/repository.clj
+++ b/src/clj_github/repository.clj
@@ -200,7 +200,7 @@
                          :method :put
                          :body   params})))
 
-(defn find-repo-path
+(defn- find-repo-path
   [clone-path]
   (->> (fs/list-dir clone-path)
        (map str)

--- a/src/clj_github/repository.clj
+++ b/src/clj_github/repository.clj
@@ -200,7 +200,9 @@
                          :body   params})))
 
 (defn clone
-  "Download github repository and put content on destination path"
+  "Download github repository and put content on destination path.
+
+  For details about the parameters and response format, look at https://docs.github.com/en/rest/reference/repos#download-a-repository-archive-zip."
   ([client org repo dest]
    (clone client org repo "" dest))
   ([client org repo tag dest]

--- a/src/clj_github/repository.clj
+++ b/src/clj_github/repository.clj
@@ -205,9 +205,9 @@
   For details about the parameters and response format, look at https://docs.github.com/en/rest/reference/repos#download-a-repository-archive-zip."
   ([client org repo dest]
    (clone client org repo "" dest))
-  ([client org repo tag dest]
+  ([client org repo ref dest]
    (let [clone-path (str (fs/temp-dir "clone-repo") "/")
-         url (format "/repos/%s/%s/zipball/%s" org repo tag)
+         url (format "/repos/%s/%s/zipball/%s" org repo ref)
          git-response (client/request client {:path   url
                                               :method :get
                                               :as     :byte-array})

--- a/src/clj_github/repository.clj
+++ b/src/clj_github/repository.clj
@@ -203,18 +203,19 @@
   "Download github repository and put content on destination path.
 
   For details about the parameters and response format, look at https://docs.github.com/en/rest/reference/repos#download-a-repository-archive-zip."
-  ([client org repo dest]
-   (clone client org repo "" dest))
-  ([client org repo ref dest]
-   (let [clone-path (str (fs/temp-dir "clone-repo") "/")
+  ([client org repo]
+   (clone client org repo ""))
+  ([client org repo ref]
+   (let [clone-path (fs/temp-dir "clone-repo")
          url (format "/repos/%s/%s/zipball/%s" org repo ref)
          git-response (client/request client {:path   url
                                               :method :get
                                               :as     :byte-array})
-         filename (->> git-response :headers :content-disposition (re-find #"filename=(.*).zip") second)]
+         filename (->> git-response :headers :content-disposition (re-find #"filename=(.*).zip") second)
+         repo-path (format "%s/%s" clone-path filename)]
      (-> git-response
          :body
          (io/input-stream)
          (io/copy (io/file clone-path "git-response.zip")))
-     (fs-compression/unzip (str clone-path "git-response.zip") clone-path)
-     (fs/move (str clone-path filename) dest))))
+     (fs-compression/unzip (str clone-path "/git-response.zip") clone-path)
+     repo-path)))


### PR DESCRIPTION
Create a new function (`clone`) that downloads a GitHub repo and put the content on destination path