### PR TITLE
Include error cause in exception if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.1
+
+- Include httpkit error in exception when available
+
 ## 0.4.0
 - Add function that downloads repository content 
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dev.nubank/clj-github "0.4.0"
+(defproject dev.nubank/clj-github "0.4.1"
   :description "A Clojure library for interacting with the github developer API"
   :url "https://github.com/nubank/clj-github"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/clj_github/httpkit_client.clj
+++ b/src/clj_github/httpkit_client.clj
@@ -33,7 +33,9 @@
   (let [response @(httpkit/request (prepare client req-map))]
     (if (success-codes (:status response))
       (update response :body (partial parse-body (content-type response)))
-      (throw (ex-info "Request to GitHub failed" {:response (select-keys response [:status :body])})))))
+      (throw (ex-info "Request to GitHub failed"
+                      {:response (select-keys response [:status :body])}
+                      (:error response))))))
 
 (defn new-client [{:keys [app-id private-key token org] :as opts}]
   (cond


### PR DESCRIPTION
Low level errors, e.g. DNS lookup failure are reported by httpkit-client in the
`:error` key of the response.

This patch adds this error as the cause of the generated exception to allow for
reporting and detection of the reason of failure.

Previously in some cases there was no detail on why the request has failed.

Signed-off-by: Philipp Meier <philipp.meier@nubank.com.br>