### PR TITLE
Add content-type application/json by default when response is a string

### DIFF
--- a/src/clj_github/test_helpers.clj
+++ b/src/clj_github/test_helpers.clj
@@ -25,7 +25,10 @@
   (reduce (fn [processed-fakes [request response]]
             (-> processed-fakes
                 (conj (spec-builder request))
-                (conj response)))
+                (conj (if (string? response)
+                        {:body response
+                         :headers {:content-type "application/json"}}
+                        response))))
           ["https://api.github.com/app/installations" "{}"]
           (partition 2 spec)))
 

--- a/src/clj_github/test_helpers.clj
+++ b/src/clj_github/test_helpers.clj
@@ -22,10 +22,10 @@
   request)
 
 (defn add-default-content-type [response]
-  (if (not (map? response))
+  (if (map? response)
+    (update-in response [:headers :content-type] #(or % "application/json"))
     {:body response
-     :headers {:content-type "application/json"}}
-    (update-in response [:headers :content-type] #(or % "application/json"))))
+     :headers {:content-type "application/json"}}))
 
 (defn build-spec [spec]
   (reduce (fn [processed-fakes [request response]]

--- a/src/clj_github/test_helpers.clj
+++ b/src/clj_github/test_helpers.clj
@@ -21,14 +21,17 @@
 (defmethod spec-builder :form [request]
   request)
 
+(defn add-default-content-type [response]
+  (if (not (map? response))
+    {:body response
+     :headers {:content-type "application/json"}}
+    (update-in response [:headers :content-type] #(or % "application/json"))))
+
 (defn build-spec [spec]
   (reduce (fn [processed-fakes [request response]]
             (-> processed-fakes
                 (conj (spec-builder request))
-                (conj (if (string? response)
-                        {:body response
-                         :headers {:content-type "application/json"}}
-                        response))))
+                (conj (add-default-content-type response))))
           ["https://api.github.com/app/installations" "{}"]
           (partition 2 spec)))
 

--- a/test/clj_github/test_helpers_test.clj
+++ b/test/clj_github/test_helpers_test.clj
@@ -35,4 +35,16 @@
                     (sut/with-fake-github ["/other" "{}"
                                            request-fn {:status 200}]
                       (httpkit-client/request client {:path "/other"})
-                      (httpkit-client/request client {:path "/api/repos"}))))))))
+                      (httpkit-client/request client {:path "/api/repos"}))))))
+
+    (testing "it adds content-type application/json by default if no content-type is provided"
+      (is (match? {:status 200 :body {:number 2}}
+                  (sut/with-fake-github ["/other" "{\"number\": 2}"]
+                                        (httpkit-client/request client {:path "/other"})))))
+
+    (testing "it maintains the content-type if one is provided"
+      (is (match? {:status 200 :body "{\"number\": 2}"}
+                  (sut/with-fake-github ["/other" {:body "{\"number\": 2}"
+                                                   :headers {:content-type "text/html"}}]
+                                        (httpkit-client/request client {:path "/other"})))))))
+


### PR DESCRIPTION
### Problem

Changes in version 0.3.0 is forcing us to change mocked responses that are strings into maps specifying the content-type as application/json.

From

```clojure
(defn initial-state-expecting-create-pr-requests [expected-migrations]
  (assoc base-state
    :responses
    [(create-pr-request? "[Auto] Refactors -" expected-migrations) "{\"number\": 2}"
     (add-label-request? 2) "{}"]))
```

To 
```clojure
(defn initial-state-expecting-create-pr-requests [expected-migrations]
  (assoc base-state
    :responses
    [(create-pr-request? "[Auto] Refactors -" expected-migrations) {:body "{\"number\": 2}" {:headers {:content-type "application/json"}}
     (add-label-request? 2) {:body "{}" :headers {:content-type "application/json"}}]))
```

### Proposal

If the mocked response is a string wrap it in a map including content-type application/json.