### PR TITLE
Fix update-check-run! overloads with same arity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1
+
+- Fix `clj-github.check/update-check-run!` overloads with same arity
+
 ## 0.5.0
 
 - Functions to create and delete a label from an issue, merge a pull request, and new namespace to work with check runs via GitHub API.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dev.nubank/clj-github "0.5.0"
+(defproject dev.nubank/clj-github "0.5.1"
   :description "A Clojure library for interacting with the github developer API"
   :url "https://github.com/nubank/clj-github"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/clj_github/check.clj
+++ b/src/clj_github/check.clj
@@ -30,12 +30,8 @@
   "Updates a check run using its id.
 
   For details about the parameters and response format, look at https://docs.github.com/en/rest/reference/checks#update-a-check-run."
-  ([client org repo id params]
-   (fetch-body! client {:path (str (check-run-url org repo) "/" id)
-                        :headers {"Accept" "application/vnd.github.v3+json"}
-                        :method :patch
-                        :body params}))
-  ([client org repo id status]
-   (update-check-run! client org repo id {:status status}))
-  ([client org repo id conclusion]
-   (update-check-run! client org repo id {:conclusion conclusion})))
+  [client org repo id params]
+  (fetch-body! client {:path (str (check-run-url org repo) "/" id)
+                       :headers {"Accept" "application/vnd.github.v3+json"}
+                       :method :patch
+                       :body params}))


### PR DESCRIPTION
Fix update-check-run! overloads with the same arity, by removing the overloads that were creating the params with status and conclusion.