### PR TITLE
Use user.home Java property to determine a user’s home directory

### DIFF
--- a/src/clj_github/token.clj
+++ b/src/clj_github/token.clj
@@ -12,7 +12,7 @@
 (def hub-config
   (memoize
    (fn []
-     (some-> (io/file (System/getenv "HOME") ".config/hub")
+     (some-> (io/file (System/getProperty "user.home") ".config/hub")
              file-exists-or-nil
              (slurp)
              yaml/parse-string


### PR DESCRIPTION
This adds windows compatibility where the $HOME environment variable
is not defined.