### PR TITLE
Add get pull files

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,11 +14,10 @@
             [lein-ancient "0.6.14" :exclusions [commons-logging com.fasterxml.jackson.core/jackson-databind com.fasterxml.jackson.core/jackson-core]]]
 
   :dependencies [[org.clojure/clojure "1.10.3"]
-
                  [cheshire "5.10.1"]
                  [clj-commons/clj-yaml "0.7.107"]
                  [http-kit "2.5.3"]
-                 [nubank/clj-github-app "0.1.5"]
+                 [nubank/clj-github-app "0.1.4"]
                  [nubank/state-flow "5.14.0"]
                  [clj-commons/fs "1.6.310"]]
 

--- a/src/clj_github/pull.clj
+++ b/src/clj_github/pull.clj
@@ -1,7 +1,7 @@
 (ns clj-github.pull
   "Provides functions to work with pull requests via github api."
-  (:require [clj-github.httpkit-client :as github-client]
-            [clj-github.client-utils :refer [fetch-body!]]))
+  (:require [clj-github.client-utils :refer [fetch-body!]]
+            [clj-github.httpkit-client :as github-client]))
 
 (defn- pull-url
   ([org repo]
@@ -59,3 +59,9 @@
   (fetch-body! client {:path   (str (pull-url org repo pull-number) "/merge")
                        :method :put
                        :body   params}))
+
+(defn get-pull-files!
+  "Get files changed in a pull request."
+  [client org repo pull-number]
+  (fetch-body! client {:path   (str (pull-url org repo pull-number) "/files")
+                       :method :get}))


### PR DESCRIPTION
Adding a function to get the files changed in a pull request. More information about this endpoint can be found [here](https://docs.github.com/en/rest/reference/pulls#list-pull-requests-files).
I also am changing the version of [clj-github-app](https://github.com/nubank/clj-github-app) because it was in a wrong version and leiningen was having problems to load the dependencies.