### PR TITLE
Create blob objects and add in the commit other files than text files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.6.0
+- Function to create blob objects and add in the commit other files than text files
+
 ## 0.5.1
 
 - Fix `clj-github.check/update-check-run!` overloads with same arity
@@ -17,7 +20,7 @@
 - Include httpkit error in exception when available
 
 ## 0.4.0
-- Add function that downloads repository content 
+- Add function that downloads repository content
 
 ## 0.3.0
 - Support content types other than json

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dev.nubank/clj-github "0.5.2"
+(defproject dev.nubank/clj-github "0.6.0"
   :description "A Clojure library for interacting with the github developer API"
   :url "https://github.com/nubank/clj-github"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/clj_github/changeset.clj
+++ b/src/clj_github/changeset.clj
@@ -75,18 +75,6 @@
   [revision path]
   (assoc-in revision [:changes path] ::deleted))
 
-(defn put-object!
-  "Creates a blob object with the encoded content.
-  Returns a new changeset with the file under path with new encoded content and sha.
-  `content` the blob's content.
-  `encoding` the encoding used for content. `utf-8` and `base64` are supported.
-  It creates a new file if it does not exist yet."
-  [{:keys [client org repo] :as changeset} path content encoding]
-  (let [{:keys [sha]} (repository/create-blob! client org repo {:content content
-                                                                :encoding encoding})]
-    (assoc-in changeset [:changes path] {:content content
-                                         :sha sha})))
-
 (defn dirty?
   "Returns true if changes were made to the given changeset"
   [{:keys [changes]}]

--- a/src/clj_github/changeset.clj
+++ b/src/clj_github/changeset.clj
@@ -75,17 +75,36 @@
   [revision path]
   (assoc-in revision [:changes path] ::deleted))
 
+(defn put-object!
+  "Creates a blob object with the encoded content.
+  Returns a new changeset with the file under path with new encoded content and sha.
+  `content` the blob's content.
+  `encoding` the encoding used for content. `utf-8` and `base64` are supported.
+  It creates a new file if it does not exist yet."
+  [{:keys [client org repo] :as changeset} path content encoding]
+  (let [{:keys [sha]} (repository/create-blob! client org repo {:content content
+                                                                :encoding encoding})]
+    (assoc-in changeset [:changes path] {:content content
+                                         :sha sha})))
+
 (defn dirty?
   "Returns true if changes were made to the given changeset"
   [{:keys [changes]}]
   (not (empty? changes)))
 
+(defn- deleted? [content]
+  (#{::deleted} content))
+
+(defn- has-sha? [content]
+  (some? (:sha content)))
+
 (defn- change->tree-object [[path content]]
   (let [base-object {:path path
                      :mode "100644"
                      :type "blob"}]
-    (case content
-      ::deleted (assoc base-object :sha nil)
+    (condp apply [content]
+      deleted? (assoc base-object :sha nil)
+      has-sha? (assoc base-object :sha (:sha content))
       (assoc base-object :content content))))
 
 (defn- changes->tree [changes]

--- a/src/clj_github/repository.clj
+++ b/src/clj_github/repository.clj
@@ -4,7 +4,6 @@
             [clj-github.httpkit-client :as client]
             [clojure.java.io :as io]
             [clojure.string :as string]
-            [clojure.string :as str]
             [me.raynes.fs :as fs]
             [me.raynes.fs.compression :as fs-compression])
   (:import [clojure.lang ExceptionInfo]
@@ -204,7 +203,7 @@
   [clone-path]
   (->> (fs/list-dir clone-path)
        (map str)
-       (remove #(str/ends-with? % ".zip"))
+       (remove #(string/ends-with? % ".zip"))
        first))
 
 (defn clone
@@ -225,3 +224,10 @@
          (io/copy (io/file clone-path "git-response.zip")))
      (fs-compression/unzip (str clone-path "/git-response.zip") clone-path)
      (find-repo-path clone-path))))
+
+(defn create-blob!
+  [client org repo body]
+  (fetch-body! client {:path (format "/repos/%s/%s/git/blobs" org repo)
+                       :headers {"Accept" "application/vnd.github.v3+json"}
+                       :method :post
+                       :body body}))

--- a/src/clj_github/repository.clj
+++ b/src/clj_github/repository.clj
@@ -225,12 +225,21 @@
      (fs-compression/unzip (str clone-path "/git-response.zip") clone-path)
      (find-repo-path clone-path))))
 
+(defn- byte-array->base64
+  ([byte-array] (byte-array->base64 byte-array (Base64/getEncoder)))
+  ([byte-array encoder] (.encodeToString encoder byte-array)))
+
 (defn create-blob!
   "Creates a new blob object.
+  `content` the blob's content. It must be a byte-array when not using the `encoding` argument.
+  `encoding` the encoding used for content. `utf-8` and `base64` are supported.
 
   For details about the parameters and response format, look at https://docs.github.com/en/rest/git/blobs#create-a-blob"
-  [client org repo body]
-  (fetch-body! client {:path (format "/repos/%s/%s/git/blobs" org repo)
-                       :headers {"Accept" "application/vnd.github.v3+json"}
-                       :method :post
-                       :body body}))
+  ([client org repo content]
+   (create-blob! client org repo (byte-array->base64 content) "base64"))
+  ([client org repo content encoding]
+   (fetch-body! client {:path (format "/repos/%s/%s/git/blobs" org repo)
+                        :headers {"Accept" "application/vnd.github.v3+json"}
+                        :method :post
+                        :body {:content content
+                               :encoding encoding}})))

--- a/src/clj_github/repository.clj
+++ b/src/clj_github/repository.clj
@@ -225,21 +225,12 @@
      (fs-compression/unzip (str clone-path "/git-response.zip") clone-path)
      (find-repo-path clone-path))))
 
-(defn- byte-array->base64
-  ([byte-array] (byte-array->base64 byte-array (Base64/getEncoder)))
-  ([byte-array encoder] (.encodeToString encoder byte-array)))
-
 (defn create-blob!
   "Creates a new blob object.
-  `content` the blob's content. It must be a byte-array when not using the `encoding` argument.
-  `encoding` the encoding used for content. `utf-8` and `base64` are supported.
 
   For details about the parameters and response format, look at https://docs.github.com/en/rest/git/blobs#create-a-blob"
-  ([client org repo content]
-   (create-blob! client org repo (byte-array->base64 content) "base64"))
-  ([client org repo content encoding]
-   (fetch-body! client {:path (format "/repos/%s/%s/git/blobs" org repo)
-                        :headers {"Accept" "application/vnd.github.v3+json"}
-                        :method :post
-                        :body {:content content
-                               :encoding encoding}})))
+  [client org repo body]
+  (fetch-body! client {:path (format "/repos/%s/%s/git/blobs" org repo)
+                       :headers {"Accept" "application/vnd.github.v3+json"}
+                       :method :post
+                       :body body}))

--- a/src/clj_github/repository.clj
+++ b/src/clj_github/repository.clj
@@ -226,6 +226,9 @@
      (find-repo-path clone-path))))
 
 (defn create-blob!
+  "Creates a new blob object.
+
+  For details about the parameters and response format, look at https://docs.github.com/en/rest/git/blobs#create-a-blob"
   [client org repo body]
   (fetch-body! client {:path (format "/repos/%s/%s/git/blobs" org repo)
                        :headers {"Accept" "application/vnd.github.v3+json"}


### PR DESCRIPTION
This PR aims to provide a way to upload files other than text files using the GitHub API.

- `repository/create-blob!`:  Function to create blob objects.