### PR TITLE
Fix branch name error with special char

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.6.3
+- Fix special characters on branch name
+
 ## 0.6.2
 - Bump `clj-github-app` version
 

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,8 @@
                  [http-kit "2.5.3"]
                  [nubank/clj-github-app "0.2.1"]
                  [nubank/state-flow "5.14.0"]
-                 [clj-commons/fs "1.6.310"]]
+                 [clj-commons/fs "1.6.310"]
+                 [ring.util.codec "1.1.3"]]
 
   :cljfmt {:indents {flow       [[:block 1]]
                      assoc-some [[:block 0]]}}

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                  [nubank/clj-github-app "0.2.1"]
                  [nubank/state-flow "5.14.0"]
                  [clj-commons/fs "1.6.310"]
-                 [ring.util.codec "1.1.3"]]
+                 [ring/ring-codec "1.2.0"]]
 
   :cljfmt {:indents {flow       [[:block 1]]
                      assoc-some [[:block 0]]}}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dev.nubank/clj-github "0.6.2"
+(defproject dev.nubank/clj-github "0.6.3"
   :description "A Clojure library for interacting with the github developer API"
   :url "https://github.com/nubank/clj-github"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/clj_github/repository.clj
+++ b/src/clj_github/repository.clj
@@ -75,7 +75,7 @@
   Look at https://developer.github.com/v3/repos/branches/#get-a-branch for details about the response format."
   [client org repo branch]
   (fetch-body! client {:method :get
-                       :path (format "/repos/%s/%s/branches/%s" org repo (encode/form-encode branch))}))
+                       :path (format "/repos/%s/%s/branches/%s" org repo (codec/url-encode branch))}))
 
 (defn get-tree!
   "Returns information about a tree.

--- a/src/clj_github/repository.clj
+++ b/src/clj_github/repository.clj
@@ -6,7 +6,7 @@
             [clojure.string :as string]
             [me.raynes.fs :as fs]
             [me.raynes.fs.compression :as fs-compression]
-            [ring.util.codec :as encode])
+            [ring.util.codec :as codec])
   (:import [clojure.lang ExceptionInfo]
            [java.util Base64]))
 

--- a/src/clj_github/repository.clj
+++ b/src/clj_github/repository.clj
@@ -5,7 +5,8 @@
             [clojure.java.io :as io]
             [clojure.string :as string]
             [me.raynes.fs :as fs]
-            [me.raynes.fs.compression :as fs-compression])
+            [me.raynes.fs.compression :as fs-compression]
+            [ring.util.codec :as encode])
   (:import [clojure.lang ExceptionInfo]
            [java.util Base64]))
 
@@ -74,7 +75,7 @@
   Look at https://developer.github.com/v3/repos/branches/#get-a-branch for details about the response format."
   [client org repo branch]
   (fetch-body! client {:method :get
-                       :path (format "/repos/%s/%s/branches/%s" org repo branch)}))
+                       :path (format "/repos/%s/%s/branches/%s" org repo (encode/form-encode branch))}))
 
 (defn get-tree!
   "Returns information about a tree.

--- a/test/clj_github/httpkit_client_test.clj
+++ b/test/clj_github/httpkit_client_test.clj
@@ -4,7 +4,7 @@
     [clj-github.httpkit-client :as sut]
     [matcher-combinators.clj-test]
     [org.httpkit.fake :refer [with-fake-http]]
-    [ring.util.codec :as encode]))
+    [ring.util.codec :as codec]))
 
 (deftest request-test
   (let [client (sut/new-client {:token-fn (fn [] "token")})]
@@ -49,4 +49,4 @@
     (testing "url path contains special character `|`"
       (with-fake-http [{:url "https://api.github.com/test%7Ctest"}
                        {:status 200}]
-                      (is (match? {:status 200} (sut/request client {:path (str "/" (encode/form-encode "test|test"))})))))))
+                      (is (match? {:status 200} (sut/request client {:path (str "/" (codec/url-encode "test|test"))})))))))


### PR DESCRIPTION
The Bookworm service was breaking when there was a `|` on the branch name. This fixes the issue by encoding all special characters that exist in the branch name

Issue: https://github.com/nubank/bookworm/issues/506