### PR TITLE
Encode ref parameter in update-reference! from repository.clj namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.6.4
+- Encode ref parameter in update-reference! from repository.clj namespace
+
 ## 0.6.3
 - Fix special characters on branch name
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dev.nubank/clj-github "0.6.3"
+(defproject dev.nubank/clj-github "0.6.4"
   :description "A Clojure library for interacting with the github developer API"
   :url "https://github.com/nubank/clj-github"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/clj_github/repository.clj
+++ b/src/clj_github/repository.clj
@@ -148,7 +148,7 @@
 
   Look at https://developer.github.com/v3/git/refs/#update-a-reference for details about the parameters and response format."
   [client org repo ref params]
-  (fetch-body! client {:path (format "/repos/%s/%s/git/refs/%s" org repo ref)
+  (fetch-body! client {:path (format "/repos/%s/%s/git/refs/%s" org repo (codec/url-encode ref))
                        :headers {"Accept" "application/vnd.github.v3+json"}
                        :method :patch
                        :body params}))


### PR DESCRIPTION
When updating the branch with a special character we got some errors due to non-encoding the reference.
Fixing by encoding the ref parameter in update-reference! from repository.clj namespace