### PR TITLE
Rework with-fake-github to more fully support with-fake-http options

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -24,7 +24,12 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.java-version }}
 
-      - name: Print java version
+      - name: Setup Clojure
+        uses: DeLaGuardo/setup-clojure@13.2
+        with:
+          lein: 2.9.1
+
+      - name: Print Java version
         run: java -version
 
       - name: Install dependencies

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -29,6 +29,14 @@ jobs:
         with:
           lein: 2.9.1
 
+      - name: Cache Clojure dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+          # List all files containing dependencies:
+          key: cljdeps-${{ hashFiles('project.clj') }}
+
       - name: Print Java version
         run: java -version
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,19 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.java-version }}
 
+      - name: Setup Clojure
+        uses: DeLaGuardo/setup-clojure@13.2
+        with:
+          lein: 2.9.1
+
+      - name: Cache Clojure dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+          # List all files containing dependencies:
+          key: cljdeps-${{ hashFiles('project.clj') }}
+
       - name: Print java version
         run: java -version
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ pom.xml.asc
 .lein-failures
 .nrepl-port
 .cpcache/
+*.iml
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.0
+
+- Revise the `with-fake-github` macro to support all the options of the underlying `with-fake-http` macro
+
 ## 0.7.1
 
 - Fix decoding bug introduced in 0.7.0

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # clj-github
 
+[![Clojars Project](https://img.shields.io/clojars/v/dev.nubank/clj-github.svg)](https://clojars.org/dev.nubank/clj-github)
+[![cljdoc badge](https://cljdoc.org/badge/dev.nubank/clj-github)](https://cljdoc.org/d/dev.nubank/clj-github)
+
 A Clojure library for interacting with the GitHub REST API.
 
 ## Httpkit client
-
 
 *Example*:
 ```clojure

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dev.nubank/clj-github "0.7.1"
+(defproject dev.nubank/clj-github "0.8.0"
   :description "A Clojure library for interacting with the github developer API"
   :url "https://github.com/nubank/clj-github"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
                  ; Dependencies required by clj-github.test-helpers and clj-github.state-flow-helper.
                  ; Must be provided by the user (typically only used in tests)
                  [http-kit.fake "0.2.2" :scope "provided"]
-                 [nubank/state-flow "5.18.0" :scope "provided"]
+                 [nubank/state-flow "5.20.1" :scope "provided"]
                  [dev.nubank/clj-github-mock "0.4.0" :scope "provided"]]
 
   :cljfmt {:indents {flow       [[:block 1]]

--- a/src/clj_github/test_helpers.clj
+++ b/src/clj_github/test_helpers.clj
@@ -1,40 +1,71 @@
 (ns clj-github.test-helpers
   (:require [clj-github-app.token-manager]
-            [org.httpkit.fake :refer [with-fake-http]]))
+            [clj-github.httpkit-client :refer [github-url]]
+            [org.httpkit.fake :as fake])
+  (:import (java.util.regex Pattern)))
+
 
 (defn- spec-type [spec]
   (cond
+    (-> spec meta :path) :path
     (string? spec) :string
     (map? spec) :map
+    (instance? Pattern spec) :pattern
     :else :form))
 
 (defmulti spec-builder spec-type)
 
 (defmethod spec-builder :string [request]
-  (str "https://api.github.com" request))
+  (str github-url request))
 
-(defmethod spec-builder :map [{:keys [path] :as request}]
-  (if path
-    (assoc request :url (str "https://api.github.com" path))
+(defmethod spec-builder :map [request]
+  (if (:path request)
+    `(let [request# ~request
+           path#    (:path request#)]
+       (assoc request# :url (str github-url path#)))
     request))
 
 (defmethod spec-builder :form [request]
   request)
 
+(defmethod spec-builder :path [form]
+  `(spec-builder ~form))
+
+(defmethod spec-builder :pattern [pattern]
+  {:url pattern})
+
+(defn -add-default-content-type
+  [response]
+  (assoc-in response [:headers :content-type] "application/json"))
+
 (defn add-default-content-type [response]
-  (if (map? response)
-    (update-in response [:headers :content-type] #(or % "application/json"))
-    {:body response
-     :headers {:content-type "application/json"}}))
+  `(let [responder# (fake/responder ~response)]
+     (fn [origin-fn# opts# callback#]
+       ((or callback# identity)
+        (responder# origin-fn# opts# -add-default-content-type)))))
 
 (defn build-spec [spec]
   (reduce (fn [processed-fakes [request response]]
             (-> processed-fakes
                 (conj (spec-builder request))
                 (conj (add-default-content-type response))))
-          ["https://api.github.com/app/installations" "{}"]
+          [(str github-url "app/installations") "{}"]
           (partition 2 spec)))
 
-(defmacro with-fake-github [spec & body]
-  `(with-fake-http ~(build-spec spec)
-     ~@body))
+(defmacro with-fake-github
+  "A wrapper around `with-fake-http` that sets up some defaults for GitHub access.
+
+  `with-fake-http` is organized with the expectation that request and response specs
+  are values; any function calls used to generate the specs look to it as if they are
+  function values that will (for requests) match or (for responses) build the response from
+  the request map.
+
+  The ^:path metadata may precede a form to indicate that the form is an expression
+  that computes the path.
+
+  The response may be any value supported by `with-fake-http` (map, integer, string, function, etc.).
+  However, the response Content-Type header is forced to \"application/json\", so the body (if provided)
+  must be a JSON value encoded as string."
+  [spec & body]
+  `(fake/with-fake-http ~(build-spec spec)
+                        ~@body))


### PR DESCRIPTION
We have an awful lot of tests that make use of `with-fake-github` and it has been somewhat problematic to use. This PR addresses our concerns, making it possible to more concisely define request matchers and to be more consistent with `with-fake-http` in how responses are generated.