### PR TITLE
Fix deployment to clojars

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4.2.2
 
+    - name: Setup Clojure
+      uses: DeLaGuardo/setup-clojure@13.2
+      with:
+        lein: 2.9.1
+
     - name: Install dependencies
       run: lein deps
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.1
+
+- No actual change beyond correcting deployment scripts
+
 ## 0.8.0
 
 - Revise the `with-fake-github` macro to support all the options of the underlying `with-fake-http` macro

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dev.nubank/clj-github "0.8.0"
+(defproject dev.nubank/clj-github "0.8.1"
   :description "A Clojure library for interacting with the github developer API"
   :url "https://github.com/nubank/clj-github"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"


### PR DESCRIPTION
For whatever reason, the scripts expected `lein` to be available by default but at some point, things changed and it must be explicitly installed.